### PR TITLE
Export a hidden module with scalar functions

### DIFF
--- a/benches/lab_to_rgb.rs
+++ b/benches/lab_to_rgb.rs
@@ -25,13 +25,12 @@ lazy_static! {
 }
 
 fn labs_to_rgbs(c: &mut Criterion) {
-    let test_name = if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-        "labs_to_rgbs_simd"
-    } else {
-        "labs_to_rgbs"
-    };
-    c.bench_function(test_name, move |b| b.iter(|| lab::labs_to_rgbs(&LABS)));
+    c.bench_function("labs_to_rgbs", move |b| b.iter(|| lab::__scalar::labs_to_rgbs(&LABS)));
 }
 
-criterion_group!(benches, labs_to_rgbs);
+fn labs_to_rgbs_simd(c: &mut Criterion) {
+    c.bench_function("labs_to_rgbs_simd", move |b| b.iter(|| lab::labs_to_rgbs(&LABS)));
+}
+
+criterion_group!(benches, labs_to_rgbs, labs_to_rgbs_simd);
 criterion_main!(benches);

--- a/benches/rgb_to_lab.rs
+++ b/benches/rgb_to_lab.rs
@@ -17,21 +17,13 @@ lazy_static! {
     };
 }
 
-// fn rgb_to_lab(c: &mut Criterion) {
-//     let rgb = RGBS[0];
-//     c.bench_function("rgb_to_lab", move |b| {
-//         b.iter(|| lab::Lab::from_rgb(&rgb))
-//     });
-// }
-
 fn rgbs_to_labs(c: &mut Criterion) {
-    let test_name = if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-        "rgbs_to_labs_simd"
-    } else {
-        "rgbs_to_labs"
-    };
-    c.bench_function(test_name, move |b| b.iter(|| lab::rgbs_to_labs(&RGBS)));
+    c.bench_function("rgbs_to_labs", move |b| b.iter(|| lab::__scalar::rgbs_to_labs(&RGBS)));
 }
 
-criterion_group!(benches, rgbs_to_labs);
+fn rgbs_to_labs_simd(c: &mut Criterion) {
+    c.bench_function("rgbs_to_labs_simd", move |b| b.iter(|| lab::rgbs_to_labs(&RGBS)));
+}
+
+criterion_group!(benches, rgbs_to_labs, rgbs_to_labs_simd);
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ pub fn rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab> {
     let labs = simd::rgbs_to_labs(rgbs);
 
     #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
-    let labs = rgbs.iter().map(Lab::from_rgb).collect();
+    let labs = __scalar::rgbs_to_labs(rgbs);
 
     labs
 }
@@ -188,9 +188,24 @@ pub fn labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]> {
     let rgbs = simd::labs_to_rgbs(labs);
 
     #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
-    let rgbs = labs.iter().map(Lab::to_rgb).collect();
+    let rgbs = __scalar::labs_to_rgbs(labs);
 
     rgbs
+}
+
+#[doc(hidden)]
+pub mod __scalar {
+    use Lab;
+
+    #[inline]
+    pub fn labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]> {
+        labs.iter().map(Lab::to_rgb).collect()
+    }
+
+    #[inline]
+    pub fn rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab> {
+        rgbs.iter().map(Lab::from_rgb).collect()
+    }
 }
 
 impl Lab {


### PR DESCRIPTION
Allows the bencher to run both simd and scalar benchmarks
without having to be recompiled with and without avx support