### PR TITLE
Add functions that work with `&[u8]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To convert slices of values
 
 * `lab::rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab>`
 * `lab::labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]>`
-* `lab::rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab>`
-* `lab::labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8>`
+* `lab::rgb_bytes_to_labs(bytes: &[u8]) -> Vec<Lab>`
+* `lab::labs_to_rgb_bytes(labs: &[Lab]) -> Vec<u8>`
 
 ```rust
 extern crate lab;
@@ -55,7 +55,7 @@ let labs = rgbs_to_labs(&rgbs);
 
 ```rust
 extern crate lab;
-use lab::rgb_slice_to_labs;
+use lab::rgb_bytes_to_labs;
 
 let rgbs = vec![
     0xFF, 0x69, 0xB6,
@@ -68,7 +68,7 @@ let rgbs = vec![
     0x76, 0x00, 0x89,
 ];
 
-let labs = rgb_slice_to_labs(&rgbs);
+let labs = rgb_bytes_to_labs(&rgbs);
 ```
 
 These functions will use x86_64 AVX2 instructions if compiled to a supported target.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
-# Rust library for converting RGB colors to the CIE-L\*a\*b\* color space
+# Lab
+
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/TooManyBees/lab?branch=master&svg=true)](https://ci.appveyor.com/project/TooManyBees/lab)
+
+Tools for converting RGB colors to L\*a\*b\* measurements.
+
+RGB colors, for this crate at least, are considered to be composed of `u8`
+values from 0 to 255, while L\*a\*b\* colors are represented by its own struct
+that uses `f32` values.
+
+# Usage
+
+## Converting single values
+
+To convert a single value, use one of the functions
+
+* `lab::Lab::from_rgb(rgb: &[u8; 3]) -> Lab`
+* `lab::Lab::from_rgba(rgba: &[u8; 4]) -> Lab` (drops the fourth alpha byte)
+* `lab::Lab::to_rgb(&self) -> [u8; 3]`
 
 ```rust
 extern crate lab;
@@ -9,48 +26,53 @@ let pink_in_lab = Lab::from_rgb(&[253, 120, 138]);
 // Lab { l: 66.639084, a: 52.251457, b: 14.860654 }
 ```
 
-```rust
-extern crate lab;
-extern crate image;
+## Converting multiple values
 
-use lab::Lab;
-use image::Rgba;
+To convert slices of values
 
-let pixel: Rgba<u8> = Rgba { data: [253, 120, 138, 255] };
-let lab = Lab::from_rgba(&pixel.data);
-// Lab { l: 66.639084, a: 52.251457, b: 14.860654 }
-```
-
-# Experimental SIMD functions
-
-The `lab::simd` module is compiled for the `x86_64` cpu architecture. If the
-current cpu can run AVX and SSE 4.1 operations, it can make use of the exported
-functions.
+* `lab::rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab>`
+* `lab::labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]>`
+* `lab::rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab>`
+* `lab::labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8>`
 
 ```rust
 extern crate lab;
-use lab::Lab;
-#[cfg(target_arch = "x86_64")]
-use lab::simd;
+use lab::rgbs_to_labs;
 
-fn convert_rgbs(rgbs: &[[u8; 3]]) -> Vec<Lab> {
-  // It's boilerplate, but it's also experimental. So.
-  #[cfg(target_arch = "x86_64")]
-  {
-      if is_x86_feature_detected!("avx") && is_x86_feature_detected!("sse4.1") {
-          return simd::rgbs_to_labs(rgbs);
-      }
-  }
-  rgbs.iter().map(Lab::from_rgb).collect()
-}
+let rgbs = vec![
+    [0xFF, 0x69, 0xB6],
+    [0xE7, 0x00, 0x00],
+    [0xFF, 0x8C, 0x00],
+    [0xFF, 0xEF, 0x00],
+    [0x00, 0x81, 0x1F],
+    [0x00, 0xC1, 0xC1],
+    [0x00, 0x44, 0xFF],
+    [0x76, 0x00, 0x89],
+];
+
+let labs = rgbs_to_labs(&rgbs);
 ```
 
-Performance increase over a serial map is wildly variable across CPUs, suggesting that
-there are still some optimizations to perform. A 2013 Macbook Air sees a \~25% decrease in benchmark times converting Labs to RGBs, and a \~40% decrease converting RGBs to Labs.
-Meanwhile a 6-core desktop computer sees near perfect 8x speedup converting Labs to RGBs,
-but a <10% improvement converting RGBs to Labs. Clearly it is a work in progress.
+```rust
+extern crate lab;
+use lab::rgb_slice_to_labs;
 
-# Minimum Rust version
+let rgbs = vec![
+    0xFF, 0x69, 0xB6,
+    0xE7, 0x00, 0x00,
+    0xFF, 0x8C, 0x00,
+    0xFF, 0xEF, 0x00,
+    0x00, 0x81, 0x1F,
+    0x00, 0xC1, 0xC1,
+    0x00, 0x44, 0xFF,
+    0x76, 0x00, 0x89,
+];
+
+let labs = rgb_slice_to_labs(&rgbs);
+```
+
+These functions will use x86_64 AVX2 instructions if compiled to a supported target.
+
+## Minimum Rust version
+
 Lab 0.7.0 requires Rust >= 1.31.0 for the [chunks_exact](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks_exact) slice method
-
-Lab 0.6.0 can build as far back as Rust 1.13.0. Testing releases gets pretty tedious earlier than that.

--- a/benches/lab_to_rgb.rs
+++ b/benches/lab_to_rgb.rs
@@ -25,12 +25,20 @@ lazy_static! {
 }
 
 fn labs_to_rgbs(c: &mut Criterion) {
-    c.bench_function("labs_to_rgbs", move |b| b.iter(|| lab::__scalar::labs_to_rgbs(&LABS)));
+    c.bench_function("[Lab] -> [RGB]", move |b| b.iter(|| lab::__scalar::labs_to_rgbs(&LABS)));
+}
+
+fn labs_to_rgb_slice(c: &mut Criterion) {
+    c.bench_function("[Lab] -> [u8]", move |b| b.iter(|| lab::__scalar::labs_to_rgb_slice(&LABS)));
 }
 
 fn labs_to_rgbs_simd(c: &mut Criterion) {
-    c.bench_function("labs_to_rgbs_simd", move |b| b.iter(|| lab::labs_to_rgbs(&LABS)));
+    c.bench_function("[Lab] -> [RGB] (simd)", move |b| b.iter(|| lab::labs_to_rgbs(&LABS)));
 }
 
-criterion_group!(benches, labs_to_rgbs, labs_to_rgbs_simd);
+fn labs_to_rgb_slice_simd(c: &mut Criterion) {
+    c.bench_function("[Lab] -> [u8] (simd)", move |b| b.iter(|| lab::labs_to_rgb_slice(&LABS)));
+}
+
+criterion_group!(benches, labs_to_rgbs, labs_to_rgb_slice, labs_to_rgbs_simd, labs_to_rgb_slice_simd);
 criterion_main!(benches);

--- a/benches/lab_to_rgb.rs
+++ b/benches/lab_to_rgb.rs
@@ -28,17 +28,17 @@ fn labs_to_rgbs(c: &mut Criterion) {
     c.bench_function("[Lab] -> [RGB]", move |b| b.iter(|| lab::__scalar::labs_to_rgbs(&LABS)));
 }
 
-fn labs_to_rgb_slice(c: &mut Criterion) {
-    c.bench_function("[Lab] -> [u8]", move |b| b.iter(|| lab::__scalar::labs_to_rgb_slice(&LABS)));
+fn labs_to_rgb_bytes(c: &mut Criterion) {
+    c.bench_function("[Lab] -> [u8]", move |b| b.iter(|| lab::__scalar::labs_to_rgb_bytes(&LABS)));
 }
 
 fn labs_to_rgbs_simd(c: &mut Criterion) {
     c.bench_function("[Lab] -> [RGB] (simd)", move |b| b.iter(|| lab::labs_to_rgbs(&LABS)));
 }
 
-fn labs_to_rgb_slice_simd(c: &mut Criterion) {
-    c.bench_function("[Lab] -> [u8] (simd)", move |b| b.iter(|| lab::labs_to_rgb_slice(&LABS)));
+fn labs_to_rgb_bytes_simd(c: &mut Criterion) {
+    c.bench_function("[Lab] -> [u8] (simd)", move |b| b.iter(|| lab::labs_to_rgb_bytes(&LABS)));
 }
 
-criterion_group!(benches, labs_to_rgbs, labs_to_rgb_slice, labs_to_rgbs_simd, labs_to_rgb_slice_simd);
+criterion_group!(benches, labs_to_rgbs, labs_to_rgb_bytes, labs_to_rgbs_simd, labs_to_rgb_bytes_simd);
 criterion_main!(benches);

--- a/benches/rgb_to_lab.rs
+++ b/benches/rgb_to_lab.rs
@@ -15,15 +15,28 @@ lazy_static! {
         let mut rng: rand::StdRng = rand::SeedableRng::from_seed(rand_seed);
         rng.sample_iter(&Standard).take(512).collect()
     };
+
+    static ref RGBS_FLAT: Vec<u8> = RGBS.iter().fold(Vec::with_capacity(RGBS.len() * 3), |mut acc, rgb| {
+        acc.extend_from_slice(rgb);
+        acc
+    });
 }
 
 fn rgbs_to_labs(c: &mut Criterion) {
-    c.bench_function("rgbs_to_labs", move |b| b.iter(|| lab::__scalar::rgbs_to_labs(&RGBS)));
+    c.bench_function("[RGB] -> [Lab]", move |b| b.iter(|| lab::__scalar::rgbs_to_labs(&RGBS)));
+}
+
+fn rgb_slice_to_labs(c: &mut Criterion) {
+    c.bench_function("[u8] -> [Lab]", move |b| b.iter(|| lab::__scalar::rgb_slice_to_labs(&RGBS_FLAT)));
 }
 
 fn rgbs_to_labs_simd(c: &mut Criterion) {
-    c.bench_function("rgbs_to_labs_simd", move |b| b.iter(|| lab::rgbs_to_labs(&RGBS)));
+    c.bench_function("[RGB] -> [Lab] (simd)", move |b| b.iter(|| lab::rgbs_to_labs(&RGBS)));
 }
 
-criterion_group!(benches, rgbs_to_labs, rgbs_to_labs_simd);
+fn rgb_slice_to_labs_simd(c: &mut Criterion) {
+    c.bench_function("[u8] -> [Lab] (simd)", move |b| b.iter(|| lab::rgb_slice_to_labs(&RGBS_FLAT)));
+}
+
+criterion_group!(benches, rgbs_to_labs, rgb_slice_to_labs, rgbs_to_labs_simd, rgb_slice_to_labs_simd);
 criterion_main!(benches);

--- a/benches/rgb_to_lab.rs
+++ b/benches/rgb_to_lab.rs
@@ -26,17 +26,17 @@ fn rgbs_to_labs(c: &mut Criterion) {
     c.bench_function("[RGB] -> [Lab]", move |b| b.iter(|| lab::__scalar::rgbs_to_labs(&RGBS)));
 }
 
-fn rgb_slice_to_labs(c: &mut Criterion) {
-    c.bench_function("[u8] -> [Lab]", move |b| b.iter(|| lab::__scalar::rgb_slice_to_labs(&RGBS_FLAT)));
+fn rgb_bytes_to_labs(c: &mut Criterion) {
+    c.bench_function("[u8] -> [Lab]", move |b| b.iter(|| lab::__scalar::rgb_bytes_to_labs(&RGBS_FLAT)));
 }
 
 fn rgbs_to_labs_simd(c: &mut Criterion) {
     c.bench_function("[RGB] -> [Lab] (simd)", move |b| b.iter(|| lab::rgbs_to_labs(&RGBS)));
 }
 
-fn rgb_slice_to_labs_simd(c: &mut Criterion) {
-    c.bench_function("[u8] -> [Lab] (simd)", move |b| b.iter(|| lab::rgb_slice_to_labs(&RGBS_FLAT)));
+fn rgb_bytes_to_labs_simd(c: &mut Criterion) {
+    c.bench_function("[u8] -> [Lab] (simd)", move |b| b.iter(|| lab::rgb_bytes_to_labs(&RGBS_FLAT)));
 }
 
-criterion_group!(benches, rgbs_to_labs, rgb_slice_to_labs, rgbs_to_labs_simd, rgb_slice_to_labs_simd);
+criterion_group!(benches, rgbs_to_labs, rgb_bytes_to_labs, rgbs_to_labs_simd, rgb_bytes_to_labs_simd);
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,12 @@ To convert slices of values
 
 * `lab::rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab>`
 * `lab::labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]>`
-* `lab::rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab>`
-* `lab::labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8>`
+* `lab::rgb_bytes_to_labs(bytes: &[u8]) -> Vec<Lab>`
+* `lab::labs_to_rgb_bytes(labs: &[Lab]) -> Vec<u8>`
 
 ```rust
 extern crate lab;
-use lab::{Lab, rgbs_to_labs};
+use lab::rgbs_to_labs;
 
 let rgbs = vec![
     [0xFF, 0x69, 0xB6],
@@ -57,7 +57,7 @@ let labs = rgbs_to_labs(&rgbs);
 
 ```rust
 extern crate lab;
-use lab::{Lab, rgb_slice_to_labs};
+use lab::rgb_bytes_to_labs;
 
 let rgbs = vec![
     0xFF, 0x69, 0xB6,
@@ -70,7 +70,7 @@ let rgbs = vec![
     0x76, 0x00, 0x89,
 ];
 
-let labs = rgb_slice_to_labs(&rgbs);
+let labs = rgb_bytes_to_labs(&rgbs);
 ```
 
 These functions will use x86_64 AVX2 instructions if compiled to a supported target.
@@ -253,12 +253,12 @@ pub fn rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab> {
     labs
 }
 
-pub fn rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab> {
+pub fn rgb_bytes_to_labs(bytes: &[u8]) -> Vec<Lab> {
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-    let labs = simd::rgb_slice_to_labs(bytes);
+    let labs = simd::rgb_bytes_to_labs(bytes);
 
     #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
-    let labs = __scalar::rgb_slice_to_labs(bytes);
+    let labs = __scalar::rgb_bytes_to_labs(bytes);
 
     labs
 }
@@ -289,12 +289,12 @@ pub fn labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]> {
 }
 
 #[inline]
-pub fn labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8> {
+pub fn labs_to_rgb_bytes(labs: &[Lab]) -> Vec<u8> {
     #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-    let bytes = simd::labs_to_rgb_slice(labs);
+    let bytes = simd::labs_to_rgb_bytes(labs);
 
     #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
-    let bytes = __scalar::labs_to_rgb_slice(labs);
+    let bytes = __scalar::labs_to_rgb_bytes(labs);
 
     bytes
 }
@@ -310,7 +310,7 @@ pub mod __scalar {
     }
 
     #[inline]
-    pub fn labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8> {
+    pub fn labs_to_rgb_bytes(labs: &[Lab]) -> Vec<u8> {
         labs.iter()
             .map(Lab::to_rgb)
             .fold(Vec::with_capacity(labs.len() * 3),|mut acc, rgb| {
@@ -325,7 +325,7 @@ pub mod __scalar {
     }
 
     #[inline]
-    pub fn rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab> {
+    pub fn rgb_bytes_to_labs(bytes: &[u8]) -> Vec<Lab> {
         bytes.chunks_exact(3)
             .map(|rgb| rgb_to_lab(rgb[0], rgb[1], rgb[2]))
             .collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,85 @@
-//! # Lab
-//!
-//! Tools for converting RGB colors to L\*a\*b\* measurements.
-//!
-//! RGB colors, for this crate at least, are considered to be an array
-//! of `u8` values (`[u8; 3]`), while L\*a\*b\* colors are represented
-//! by its own struct that uses `f32` values.
-//!
-//! # Usage
-//! ## Converting single values
-//! To convert a single value, use one of the functions
-//! * `lab::Lab::from_rgb(rgb: &[u8; 3]) -> Lab`
-//! * `lab::Lab::from_rgba(rgba: &[u8; 4]) -> Lab` (drops the fourth alpha byte)
-//! * `lab::Lab::to_rgb(&self) -> [u8; 3]`
-//!
-//! ## Converting multiple values
-//! To convert slices of values
-//! * `lab::rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab>`
-//! * `lab::labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]>`
-//!
-
 #![doc(html_root_url = "https://docs.rs/lab/0.7.1")]
+
+/*!
+
+# Lab
+
+Tools for converting RGB colors to L\*a\*b\* measurements.
+
+RGB colors, for this crate at least, are considered to be composed of `u8`
+values from 0 to 255, while L\*a\*b\* colors are represented by its own struct
+that uses `f32` values.
+
+# Usage
+
+## Converting single values
+
+To convert a single value, use one of the functions
+
+* `lab::Lab::from_rgb(rgb: &[u8; 3]) -> Lab`
+* `lab::Lab::from_rgba(rgba: &[u8; 4]) -> Lab` (drops the fourth alpha byte)
+* `lab::Lab::to_rgb(&self) -> [u8; 3]`
+
+```rust
+extern crate lab;
+use lab::Lab;
+
+let pink_in_lab = Lab::from_rgb(&[253, 120, 138]);
+// Lab { l: 66.639084, a: 52.251457, b: 14.860654 }
+```
+
+## Converting multiple values
+
+To convert slices of values
+
+* `lab::rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab>`
+* `lab::labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]>`
+* `lab::rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab>`
+* `lab::labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8>`
+
+```rust
+extern crate lab;
+use lab::{Lab, rgbs_to_labs};
+
+let rgbs = vec![
+    [0xFF, 0x69, 0xB6],
+    [0xE7, 0x00, 0x00],
+    [0xFF, 0x8C, 0x00],
+    [0xFF, 0xEF, 0x00],
+    [0x00, 0x81, 0x1F],
+    [0x00, 0xC1, 0xC1],
+    [0x00, 0x44, 0xFF],
+    [0x76, 0x00, 0x89],
+];
+
+let labs = rgbs_to_labs(&rgbs);
+```
+
+```rust
+extern crate lab;
+use lab::{Lab, rgb_slice_to_labs};
+
+let rgbs = vec![
+    0xFF, 0x69, 0xB6,
+    0xE7, 0x00, 0x00,
+    0xFF, 0x8C, 0x00,
+    0xFF, 0xEF, 0x00,
+    0x00, 0x81, 0x1F,
+    0x00, 0xC1, 0xC1,
+    0x00, 0x44, 0xFF,
+    0x76, 0x00, 0x89,
+];
+
+let labs = rgb_slice_to_labs(&rgbs);
+```
+
+These functions will use x86_64 AVX2 instructions if compiled to a supported target.
+
+## Minimum Rust version
+
+Lab 0.7.0 requires Rust >= 1.31.0 for the [chunks_exact](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks_exact) slice method
+
+*/
 
 #[cfg(test)]
 #[macro_use]

--- a/src/simd/labs_to_rgbs.rs
+++ b/src/simd/labs_to_rgbs.rs
@@ -38,7 +38,7 @@ pub fn labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]> {
     vs
 }
 
-pub fn labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8> {
+pub fn labs_to_rgb_bytes(labs: &[Lab]) -> Vec<u8> {
     let chunks = labs.chunks_exact(8);
     let remainder = chunks.remainder();
     let mut vs = chunks.fold(Vec::with_capacity(labs.len()), |mut v, labs| {
@@ -268,7 +268,7 @@ mod test {
     }
 
     #[test]
-    fn test_simd_labs_to_rgb_slice() {
+    fn test_simd_labs_to_rgb_bytes() {
         // Assert that returning a single slice of bytes returns the same values as
         // returning them in rgb triples.
         let labs = vec![
@@ -285,7 +285,7 @@ mod test {
             acc.extend_from_slice(rgb);
             acc
         });
-        let bytes = simd::labs_to_rgb_slice(&labs);
+        let bytes = simd::labs_to_rgb_bytes(&labs);
         assert_eq!(rgbs, bytes);
     }
 

--- a/src/simd/labs_to_rgbs.rs
+++ b/src/simd/labs_to_rgbs.rs
@@ -38,6 +38,31 @@ pub fn labs_to_rgbs(labs: &[Lab]) -> Vec<[u8; 3]> {
     vs
 }
 
+pub fn labs_to_rgb_slice(labs: &[Lab]) -> Vec<u8> {
+    let chunks = labs.chunks_exact(8);
+    let remainder = chunks.remainder();
+    let mut vs = chunks.fold(Vec::with_capacity(labs.len()), |mut v, labs| {
+        let rgbs = unsafe { slice_labs_to_rgb_bytes(labs) };
+        v.extend_from_slice(&rgbs);
+        v
+    });
+
+    if remainder.len() > 0 {
+        let labs: Vec<Lab> = remainder
+            .iter()
+            .cloned()
+            .chain(iter::repeat(BLANK_LAB))
+            .take(8)
+            .collect();
+
+        let rgbs = unsafe { slice_labs_to_rgb_bytes(&labs) };
+        vs.extend_from_slice(&rgbs[..remainder.len()]);
+    }
+
+    vs
+}
+
+#[allow(dead_code)]
 pub fn labs_to_rgbs_chunk(labs: &[Lab]) -> [[u8; 3]; 8] {
     unsafe { slice_labs_to_slice_rgbs(labs) }
 }
@@ -48,6 +73,14 @@ unsafe fn slice_labs_to_slice_rgbs(labs: &[Lab]) -> [[u8; 3]; 8] {
     let (x, y, z) = labs_to_xyzs(l, a, b);
     let (r, g, b) = xyzs_to_rgbs(x, y, z);
     simd_to_rgb_array(r, g, b)
+}
+
+#[inline]
+unsafe fn slice_labs_to_rgb_bytes(labs: &[Lab]) -> [u8; 8 * 3] {
+    let (l, a, b) = lab_slice_to_simd(labs);
+    let (x, y, z) = labs_to_xyzs(l, a, b);
+    let (r, g, b) = xyzs_to_rgbs(x, y, z);
+    simd_to_rgb_bytes(r, g, b)
 }
 
 #[inline]
@@ -191,7 +224,27 @@ unsafe fn simd_to_rgb_array(r: __m256, g: __m256, b: __m256) -> [[u8; 3]; 8] {
     mem::transmute(rgbs)
 }
 
-#[cfg(all(target_cpu = "x86_64", target_feature = "avx"))]
+#[inline]
+unsafe fn simd_to_rgb_bytes(r: __m256, g: __m256, b: __m256) -> [u8; 8 * 3] {
+    let r: [f32; 8] = mem::transmute(_mm256_round_ps(r, _MM_FROUND_TO_NEAREST_INT));
+    let g: [f32; 8] = mem::transmute(_mm256_round_ps(g, _MM_FROUND_TO_NEAREST_INT));
+    let b: [f32; 8] = mem::transmute(_mm256_round_ps(b, _MM_FROUND_TO_NEAREST_INT));
+
+    let mut bytes: [mem::MaybeUninit<u8>; 8 * 3] = mem::MaybeUninit::uninit().assume_init();
+    for (((&r, &g), &b), rgb) in r
+        .iter()
+        .zip(g.iter())
+        .zip(b.iter())
+        .rev()
+        .zip(bytes.chunks_exact_mut(3))
+    {
+        rgb[0] = mem::MaybeUninit::new(r as u8);
+        rgb[1] = mem::MaybeUninit::new(g as u8);
+        rgb[2] = mem::MaybeUninit::new(b as u8);
+    }
+    mem::transmute(bytes)
+}
+
 #[cfg(test)]
 mod test {
     use super::super::super::{labs_to_rgbs, simd, Lab};
@@ -212,6 +265,28 @@ mod test {
         let labs = simd::rgbs_to_labs(&RGBS);
         let rgbs = simd::labs_to_rgbs(&labs);
         assert_eq!(rgbs.as_slice(), RGBS.as_slice());
+    }
+
+    #[test]
+    fn test_simd_labs_to_rgb_slice() {
+        // Assert that returning a single slice of bytes returns the same values as
+        // returning them in rgb triples.
+        let labs = vec![
+            Lab { l: 65.55042, a: 64.48197, b: -11.685503 },
+            Lab { l: 48.25341, a: 74.3235, b: 62.362576 },
+            Lab { l: 69.485344, a: 36.825745, b: 75.4871 },
+            Lab { l: 93.01275, a: -13.856977, b: 91.47719 },
+            Lab { l: 46.70882, a: -50.29225, b: 42.086266 },
+            Lab { l: 70.86147, a: -38.99568, b: -11.459422 },
+            Lab { l: 40.166237, a: 55.847153, b: -94.75334 },
+            Lab { l: 28.53371, a: 58.779716, b: -44.23661 },
+        ];
+        let rgbs = simd::labs_to_rgbs(&labs).iter().fold(Vec::with_capacity(labs.len() * 3), |mut acc, rgb| {
+            acc.extend_from_slice(rgb);
+            acc
+        });
+        let bytes = simd::labs_to_rgb_slice(&labs);
+        assert_eq!(rgbs, bytes);
     }
 
     #[test]

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -8,5 +8,13 @@ mod rgbs_to_labs;
 mod math;
 #[cfg(test)] mod approx_impl;
 
-pub use self::labs_to_rgbs::{labs_to_rgbs, labs_to_rgbs_chunk};
-pub use self::rgbs_to_labs::{rgbs_to_labs, rgbs_to_labs_chunk};
+pub use self::labs_to_rgbs::{
+    labs_to_rgbs,
+    labs_to_rgb_slice,
+    labs_to_rgbs_chunk,
+};
+pub use self::rgbs_to_labs::{
+    rgbs_to_labs,
+    rgb_slice_to_labs,
+    rgbs_to_labs_chunk,
+};

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -10,11 +10,11 @@ mod math;
 
 pub use self::labs_to_rgbs::{
     labs_to_rgbs,
-    labs_to_rgb_slice,
+    labs_to_rgb_bytes,
     labs_to_rgbs_chunk,
 };
 pub use self::rgbs_to_labs::{
     rgbs_to_labs,
-    rgb_slice_to_labs,
+    rgb_bytes_to_labs,
     rgbs_to_labs_chunk,
 };

--- a/src/simd/rgbs_to_labs.rs
+++ b/src/simd/rgbs_to_labs.rs
@@ -33,7 +33,7 @@ pub fn rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab> {
     vs
 }
 
-pub fn rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab> {
+pub fn rgb_bytes_to_labs(bytes: &[u8]) -> Vec<Lab> {
     let chunks = bytes.chunks_exact(8 * 3);
     let remainder = chunks.remainder();
     let mut vs = chunks.fold(Vec::with_capacity(bytes.len() / 3), |mut v, bytes| {
@@ -62,7 +62,7 @@ pub fn rgbs_to_labs_chunk(rgbs: &[[u8; 3]]) -> [Lab; 8] {
 }
 
 unsafe fn slice_rgbs_to_slice_labs(rgbs: &[[u8; 3]]) -> [Lab; 8] {
-    let (r, g, b) = rgb_slice_to_simd(rgbs);
+    let (r, g, b) = rgb_bytes_to_simd(rgbs);
     let (x, y, z) = rgbs_to_xyzs(r, g, b);
     let (l, a, b) = xyzs_to_labs(x, y, z);
     simd_to_lab_array(l, a, b)
@@ -77,7 +77,7 @@ unsafe fn slice_bytes_to_slice_labs(bytes: &[u8]) -> [Lab; 8] {
 }
 
 #[inline]
-unsafe fn rgb_slice_to_simd(rgbs: &[[u8; 3]]) -> (__m256, __m256, __m256) {
+unsafe fn rgb_bytes_to_simd(rgbs: &[[u8; 3]]) -> (__m256, __m256, __m256) {
     let r = _mm256_set_ps(
         rgbs[0][0] as f32,
         rgbs[1][0] as f32,
@@ -295,7 +295,7 @@ mod test {
     }
 
     #[test]
-    fn test_simd_rgb_slice_to_labs() {
+    fn test_simd_rgb_bytes_to_labs() {
         // Assert that converting a slice of bytes and a slice of rgb triples
         // returns the same Lab values.
         let rgbs = vec![
@@ -320,7 +320,7 @@ mod test {
         ];
 
         let labs_from_triples = simd::rgbs_to_labs(&rgbs);
-        let labs_from_bytes = simd::rgb_slice_to_labs(&bytes);
+        let labs_from_bytes = simd::rgb_bytes_to_labs(&bytes);
         assert_eq!(labs_from_triples, labs_from_bytes);
     }
 

--- a/src/simd/rgbs_to_labs.rs
+++ b/src/simd/rgbs_to_labs.rs
@@ -33,12 +33,44 @@ pub fn rgbs_to_labs(rgbs: &[[u8; 3]]) -> Vec<Lab> {
     vs
 }
 
+pub fn rgb_slice_to_labs(bytes: &[u8]) -> Vec<Lab> {
+    let chunks = bytes.chunks_exact(8 * 3);
+    let remainder = chunks.remainder();
+    let mut vs = chunks.fold(Vec::with_capacity(bytes.len() / 3), |mut v, bytes| {
+        let labs = unsafe { slice_bytes_to_slice_labs(bytes) };
+        v.extend_from_slice(&labs);
+        v
+    });
+
+    if remainder.len() > 0 {
+        let bytes: Vec<u8> = remainder
+            .iter()
+            .cloned()
+            .chain(iter::repeat(0u8))
+            .take(8 * 3)
+            .collect();
+        let labs = unsafe { slice_bytes_to_slice_labs(&bytes) };
+        vs.extend_from_slice(&labs[..remainder.len() / 3]);
+    }
+
+    vs
+}
+
+#[allow(dead_code)]
 pub fn rgbs_to_labs_chunk(rgbs: &[[u8; 3]]) -> [Lab; 8] {
     unsafe { slice_rgbs_to_slice_labs(rgbs) }
 }
 
 unsafe fn slice_rgbs_to_slice_labs(rgbs: &[[u8; 3]]) -> [Lab; 8] {
     let (r, g, b) = rgb_slice_to_simd(rgbs);
+    let (x, y, z) = rgbs_to_xyzs(r, g, b);
+    let (l, a, b) = xyzs_to_labs(x, y, z);
+    simd_to_lab_array(l, a, b)
+}
+
+#[inline]
+unsafe fn slice_bytes_to_slice_labs(bytes: &[u8]) -> [Lab; 8] {
+    let (r, g, b) = byte_slice_to_simd(bytes);
     let (x, y, z) = rgbs_to_xyzs(r, g, b);
     let (l, a, b) = xyzs_to_labs(x, y, z);
     simd_to_lab_array(l, a, b)
@@ -75,6 +107,41 @@ unsafe fn rgb_slice_to_simd(rgbs: &[[u8; 3]]) -> (__m256, __m256, __m256) {
         rgbs[5][2] as f32,
         rgbs[6][2] as f32,
         rgbs[7][2] as f32,
+    );
+    (r, g, b)
+}
+
+#[inline]
+unsafe fn byte_slice_to_simd(bytes: &[u8]) -> (__m256, __m256, __m256) {
+    let r = _mm256_set_ps(
+        bytes[3*0] as f32,
+        bytes[3*1] as f32,
+        bytes[3*2] as f32,
+        bytes[3*3] as f32,
+        bytes[3*4] as f32,
+        bytes[3*5] as f32,
+        bytes[3*6] as f32,
+        bytes[3*7] as f32,
+    );
+    let g = _mm256_set_ps(
+        bytes[3*0 + 1] as f32,
+        bytes[3*1 + 1] as f32,
+        bytes[3*2 + 1] as f32,
+        bytes[3*3 + 1] as f32,
+        bytes[3*4 + 1] as f32,
+        bytes[3*5 + 1] as f32,
+        bytes[3*6 + 1] as f32,
+        bytes[3*7 + 1] as f32,
+    );
+    let b = _mm256_set_ps(
+        bytes[3*0 + 2] as f32,
+        bytes[3*1 + 2] as f32,
+        bytes[3*2 + 2] as f32,
+        bytes[3*3 + 2] as f32,
+        bytes[3*4 + 2] as f32,
+        bytes[3*5 + 2] as f32,
+        bytes[3*6 + 2] as f32,
+        bytes[3*7 + 2] as f32,
     );
     (r, g, b)
 }
@@ -194,7 +261,6 @@ unsafe fn simd_to_lab_array(l: __m256, a: __m256, b: __m256) -> [Lab; 8] {
 //     (r, g, b)
 // }
 
-#[cfg(all(target_cpu = "x86_64", target_feature = "avx"))]
 #[cfg(test)]
 mod test {
     use super::super::super::{rgbs_to_labs, simd};
@@ -226,6 +292,36 @@ mod test {
         let labs_non_simd = rgbs_to_labs(&rgbs);
         let labs_simd = simd::rgbs_to_labs(&rgbs);
         assert_relative_eq!(labs_simd.as_slice(), labs_non_simd.as_slice(), max_relative = 0.00002);
+    }
+
+    #[test]
+    fn test_simd_rgb_slice_to_labs() {
+        // Assert that converting a slice of bytes and a slice of rgb triples
+        // returns the same Lab values.
+        let rgbs = vec![
+            [253, 120, 138], // Lab { l: 66.6348, a: 52.260696, b: 14.850557 }
+            [25, 20, 22],    // Lab { l: 6.9093895, a: 2.8204322, b: -0.45616925 }
+            [63, 81, 181],   // Lab { l: 38.336494, a: 25.586218, b: -55.288517 }
+            [21, 132, 102],  // Lab { l: 49.033485, a: -36.959187, b: 7.9363704 }
+            [255, 193, 7],   // Lab { l: 81.519325, a: 9.4045105, b: 82.69791 }
+            [233, 30, 99],   // Lab { l: 50.865776, a: 74.61989, b: 15.343171 }
+            [155, 96, 132],  // Lab { l: 48.260345, a: 29.383003, b: -9.950054 }
+            [249, 165, 33],  // Lab { l: 74.29188, a: 21.827251, b: 72.75864 }
+        ];
+        let bytes = vec![
+            253, 120, 138, // Lab { l: 66.6348, a: 52.260696, b: 14.850557 }
+            25, 20, 22,    // Lab { l: 6.9093895, a: 2.8204322, b: -0.45616925 }
+            63, 81, 181,   // Lab { l: 38.336494, a: 25.586218, b: -55.288517 }
+            21, 132, 102,  // Lab { l: 49.033485, a: -36.959187, b: 7.9363704 }
+            255, 193, 7,   // Lab { l: 81.519325, a: 9.4045105, b: 82.69791 }
+            233, 30, 99,   // Lab { l: 50.865776, a: 74.61989, b: 15.343171 }
+            155, 96, 132,  // Lab { l: 48.260345, a: 29.383003, b: -9.950054 }
+            249, 165, 33,  // Lab { l: 74.29188, a: 21.827251, b: 72.75864 }
+        ];
+
+        let labs_from_triples = simd::rgbs_to_labs(&rgbs);
+        let labs_from_bytes = simd::rgb_slice_to_labs(&bytes);
+        assert_eq!(labs_from_triples, labs_from_bytes);
     }
 
     #[test]


### PR DESCRIPTION
Add functions that accept/return `&[u8]` instead of `&[[u8; 3]]`, since
it's more likely to have a slice of bytes representing RGB values,
rather than having them neatly chunked into arrays ahead of time.

Also update the README to account for them